### PR TITLE
fix(simple_storage): ensure cache removal is persisted

### DIFF
--- a/lib/utils/simple_storage.dart
+++ b/lib/utils/simple_storage.dart
@@ -148,8 +148,8 @@ class SimpleStorage {
         }
       }
 
-      // 强制保存更改
-      await prefs.commit();
+      // 重新加载偏好设置以确保删除操作被持久化
+      await prefs.reload();
 
       debugPrint('SimpleStorage: 已删除 $removedCount/${cacheKeys.length} 个缓存项');
 


### PR DESCRIPTION
## Summary
- replace deprecated commit call with reload when clearing cached answers

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68ac4904150c8322a95615bba9efa409